### PR TITLE
Added timeout to fuzzer and simulated delay for tests

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -44,14 +44,20 @@ func RunFuzzTests(t *testing.T, start, end int, fuzzer *Fuzzer) string {
 	for i := start; i < end; i++ {
 		result, err := fuzzer.Fuzz()
 
-		if err != nil && err.Error() == "input string is too long" {
-			// Log expected error without failing the test
-			t.Logf("Test %d: Expected error - %v", i+1, err)
-			report += fmt.Sprintf("Test %d: Error - %v\n", i+1, err)
-		} else if err != nil {
-			// Log unexpected error and fail the test
-			t.Errorf("Test %d: Unexpected error - %v", i+1, err)
-			report += fmt.Sprintf("Test %d: Unexpected error - %v\n", i+1, err)
+		if err != nil {
+			if err.Error() == "test timed out" {
+				// Log timeout without failing test
+				t.Logf("Test %d: Timeout - %v", i+1, err)
+				report += fmt.Sprintf("Test %d: Timeout - %v\n", i+1, err)
+			} else if err.Error() == "input string is too long" {
+				// Log expected error without failing the test
+				t.Logf("Test %d: Expected error - %v", i+1, err)
+				report += fmt.Sprintf("Test %d: Expected error - %v\n", i+1, err)
+			} else {
+				// Log unexpected error and fail the test
+				t.Errorf("Test %d: Unexpected error - %v", i+1, err)
+				report += fmt.Sprintf("Test %d: Unexpected error - %v\n", i+1, err)
+			}
 		} else {
 			// Log success
 			t.Logf("Test %d: Success - %s", i+1, result)

--- a/fuzzer.go
+++ b/fuzzer.go
@@ -1,19 +1,23 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
+	"time"
 )
 
-// Fuzzer struct that holds a function to be fuzzed
+// Fuzzer struct that holds a function to be fuzzed and a timeout
 type Fuzzer struct {
 	testFunction func(string) (string, error) // The function to be fuzzed
+	timeout      time.Duration                // Timeout duration for each test
 }
 
-// NewFuzzer creates a new fuzzer instance
+// NewFuzzer creates a new fuzzer instance with a timeout
 func NewFuzzer(testFunction func(string) (string, error)) *Fuzzer {
 	return &Fuzzer{
 		testFunction: testFunction,
+		timeout:      3 * time.Second, // 3-second timeout
 	}
 }
 
@@ -27,14 +31,32 @@ func (f *Fuzzer) randomString(length int) string {
 	return string(s)
 }
 
-// Fuzz generates random inputs, tests the function, and returns the result and any error
+// Fuzz generates random inputs, tests the function with a timeout, and returns the result and any error
 func (f *Fuzzer) Fuzz() (string, error) {
 	input := f.randomString(rand.Intn(20) + 1) // Generate a random string of length 1 to 20
-	result, err := f.testFunction(input)       // Call the function being fuzzed
-	if err != nil {
-		fmt.Printf("Error with input '%s': %v\n", input, err) // Print the error if one occurs
+	resultChan := make(chan string)
+	errorChan := make(chan error)
+
+	// Run the test function in a separate goroutine
+	go func() {
+		result, err := f.testFunction(input) // Call the function being fuzzed
+		if err != nil {
+			errorChan <- err
+		} else {
+			resultChan <- result
+		}
+	}()
+
+	// Use select to handle either a result, an error, or a timeout
+	select {
+	case result := <-resultChan:
+		fmt.Printf("Success with input '%s': %s\n", input, result)
+		return result, nil
+	case err := <-errorChan:
+		fmt.Printf("Error with input '%s': %v\n", input, err)
 		return "", err
+	case <-time.After(f.timeout):
+		fmt.Printf("Test timed out after %v seconds for input: %s\n", f.timeout.Seconds(), input)
+		return "", errors.New("test timed out")
 	}
-	fmt.Printf("Success with input '%s': %s\n", input, result) // Print success
-	return result, nil
 }

--- a/string_processor.go
+++ b/string_processor.go
@@ -3,15 +3,21 @@ package main
 import (
 	"errors"
 	"fmt"
+	"math/rand"
+	"time"
 )
 
 // processString processes the input string and returns an error if the string is too long
 func processString(input string) (string, error) {
+	// simulate varying times of function
+	delay := rand.Intn(6) // Random delay between 0 and 5 seconds
+	time.Sleep(time.Duration(delay) * time.Second)
+
 	// Strings longer than 10 characters are invalid
 	if len(input) > 10 {
 		return "", errors.New("input string is too long")
 	}
 
-	// If the string is valid, return the processed result
+	// If the string is valid and processing completes in time, return the processed result
 	return fmt.Sprintf("Processed: %s", input), nil
 }


### PR DESCRIPTION
This pull request introduces a 3-second timeout feature to the fuzzer, ensuring that any tests that take longer than this duration to process are reported as timeouts. Introduced random delays in the test functions to effectively test the timeout feature.